### PR TITLE
feat: show payment option only if the threshold of 0.5 is reached

### DIFF
--- a/src/Payment/Stripe.php
+++ b/src/Payment/Stripe.php
@@ -3,6 +3,7 @@
 namespace Webkul\Stripe\Payment;
 
 use Illuminate\Support\Facades\Storage;
+use Webkul\Checkout\Facades\Cart;
 use Webkul\Payment\Payment\Payment;
 
 class Stripe extends Payment
@@ -17,6 +18,11 @@ class Stripe extends Payment
     public function getRedirectUrl(): string
     {
         return route('stripe.process');
+    }
+
+    public function isAvailable()
+    {
+        return Cart::getCart()->grand_total >= 0.5;
     }
 
     /**

--- a/src/Payment/Stripe.php
+++ b/src/Payment/Stripe.php
@@ -20,7 +20,12 @@ class Stripe extends Payment
         return route('stripe.process');
     }
 
-    public function isAvailable()
+    /**
+     * Checks if the cart grand total is greater than 0.5.
+     *
+     * @return bool
+     */
+    public function isAvailable(): bool
     {
         return Cart::getCart()->grand_total >= 0.5;
     }


### PR DESCRIPTION
Inside the `src/Payment/Stripe.php`, the method `isAvailable` has been overwritten to handle the minimun amount (edge case) required by Stripe for a transaction (0.5).
When the method returns `false` the Stripe payment option is not displayed to prevent the following error:
![photo_2024-04-26_13-40-45](https://github.com/codenteq/stripe-payment-gateway/assets/29805626/d86afa30-e151-4c9e-b6ca-d1a5c45ce48e)
