### PR TITLE
removes explicit payment_method_types to allow stripe to auto handle …

### DIFF
--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -42,7 +42,6 @@ class PaymentController extends Controller
         $totalAmount = $cart->grand_total;
 
         $checkoutSession = Session::create([
-            'payment_method_types' => ['card'],
             'line_items'           => [[
                 'price_data' => [
                     'currency'     => $cart->global_currency_code,


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#12 
## Description

---
name: "🐛 Bug Report : Auto Handle Payment Methods based on UI Settings"
about: 'Report a general issue when trying to use other payment methods shown in the Checkout Page'
---

# Bug Report
<!--- Before you open an issue, please check if the issue already has been reported. --->

## Issue Description
<!--- Provide a more detailed introduction to the issue itself. -->
Hey there, I used the plugin for Bagisto, works great. While using it I found out that there is a small issue on the Payment Controller where the checkoutSession is created. Your plugin passes explicitly the payment_method_types 'card' , this will disable the capabilities of Stripe to handle the methods via the settings over the admin ui. Simply removing this line will do the fix. I'm submitting a PR for you.

## Preconditions
<!--- Please provide as detailed information about your environment as possible. -->
Using Bagisto latest version (2.2 I think) and Laravel 10.ss , with the latest stripe API (as of 9 October 2024)
## Steps To Reproduce
<!--- It is important to provide a set of clear steps to reproduce this bug. If relevant please include code samples. -->

1. Install Bagisto composer create-project bagisto/bagisto and seed demo products
2. Install your plugin stripe-payment-gateway
3. create developer account on stripe
4. Enable other payment methods via the UI over https://dashboard.stripe.com/test/settings/payment_methods, for instance Apple Pay, Klarna, Link, Google Pay
5. Login as admin to bagisto's admin dashboard and enable payment method stripe providing api key and so on
6. Run your app locally
7. login as customer
8. Create Customer account and login
9. select product and add to cart
10. go to payment and select stripe


## Actual Result
<!--- Tell us what happens instead.-->
11. then before this fix you'll see only the card payment method

## Expected Result
<!--- Tell us what should happen. -->
13. after the fix you'll see all the other payment methods which are automatically handled by stripe and display on the checkout

