### PR TITLE
fix: add missing details for the order

### DIFF
--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -65,11 +65,9 @@ class PaymentController extends Controller
      */
     public function success(): RedirectResponse
     {
-        $cart = Cart::getCart();
+        Cart::collectTotals();
 
-        $data = (new OrderResource($cart))->jsonSerialize();
-
-        $order = $this->orderRepository->create($data);
+        $order = $this->orderRepository->create(Cart::prepareDataForOrder());
 
         if ($order->canInvoice()) {
             $this->invoiceRepository->create($this->prepareInvoiceData($order));


### PR DESCRIPTION
Without the `Cart::prepareDataForOrder()` the order details are not shown in the order details page on the admin panel